### PR TITLE
s/deepEqual/deep.equal

### DIFF
--- a/_workshop/05-4-parse-url.js
+++ b/_workshop/05-4-parse-url.js
@@ -117,7 +117,7 @@ describe('pairOn', function() {
   it('should give the correct object when called with _.object', function() {
     var result = _.object(pairOn('=', values));
 
-    expect(result).to.deepEqual(parsedUrl);
+    expect(result).to.deep.equal(parsedUrl);
   });
 });
 
@@ -133,7 +133,7 @@ describe('parseUrl', function() {
   it('should give the correct object when called', function() {
     var result = parseUrl(url);
 
-    expect(result).to.deepEqual(parsedUrl);
+    expect(result).to.deep.equal(parsedUrl);
   });
 });
 
@@ -150,7 +150,7 @@ var composedParseUrl = _.compose(
 describe('composedParseUrl', function() {
   it('should give the correct object when called', function() {
     var result = composedParseUrl(url);
-    expect(result).to.deepEqual(parsedUrl);
+    expect(result).to.deep.equal(parsedUrl);
   });
 });
 


### PR DESCRIPTION
Fixes error `expect(...).to.deepEqual is not a function` in tests 4-6 of "Case - Parse URL"
